### PR TITLE
feat: run revive only on staged files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Add this to your `.pre-commit-config.yaml`
 - `go-mod-tidy` - Run `go mod tidy -v`, requires golang
 - `go-get-update` - Run `go get -u -v ./...` to update all project dependencies if there are any available
 - `goimports-reviser` - Run `goimports-reviser -format [args] ./...` to format all golang files (requires [goimports-reviser cli](https://github.com/incu6us/goimports-reviser))
+- `revive` - Runs `revive` to inspect all staged files (requires [revive](https://github.com/mgechev/revive))

--- a/run-revive.sh
+++ b/run-revive.sh
@@ -9,10 +9,16 @@ if [ $# -gt 0 ]; then
   command="$command $@"
 fi
 
-command="$command ./..."
+staged_files=$(git diff --cached --name-only | grep '\.go$' | tr '\n' ' ')
 
-echo "Running: $command"
+if [ -n "$staged_files" ]; then
+  # If "files" is not empty, run the revive command
+  command="$command $staged_files"
 
-exec 5>&1
-output="$($command | tee /dev/fd/5)"
-[[ -z "$output" ]]
+  echo "Running: $command"
+
+  exec 5>&1
+  output="$($command | tee /dev/fd/5)"
+  [[ -z "$output" ]]
+fi
+


### PR DESCRIPTION
Con este PR, nos aseguramos de que revive corra unicamente sobre los archivos cone extensión `.go` que estan staged para el commit.

Se probó y funciona bien