### PR TITLE
fix: filter deleted staged files to revive hook

### DIFF
--- a/run-revive.sh
+++ b/run-revive.sh
@@ -9,7 +9,7 @@ if [ $# -gt 0 ]; then
   command="$command $@"
 fi
 
-staged_files=$(git diff --cached --name-only | grep '\.go$' | tr '\n' ' ')
+staged_files=$(git diff --cached --name-only --diff-filter=ACMRTUXB | grep '\.go$' | tr '\n' ' ')
 
 if [ -n "$staged_files" ]; then
   # If "files" is not empty, run the revive command


### PR DESCRIPTION
El hook de revive está dando error cuando hay files eliminados.

Agrega un filtro de los eliminados en el comando que detecta los cambios (--diff-filter=ACMRTUXB) para solucionarlo.