### PR TITLE
feat: force mod version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,17 @@ jobs:
       version: ${{ steps.cz.outputs.version }}
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: "${{ secrets.ACCESS_TOKEN }}"
           ref: "master"
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Setup Langs
+        uses: Drafteame/setup-ci-langs@v0.8.0
         with:
-          python-version: 3.8
+          python: 'true'
+          go: 'false'
 
       - name: Config Git User
         run: |
@@ -63,7 +64,7 @@ jobs:
       - bump_version
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: "${{ secrets.ACCESS_TOKEN }}"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -57,6 +57,7 @@
     name: 'goimports-reviser'
     entry: run-goimports-reviser.sh
     files: '\.go$'
+    pass_filenames: false
     language: 'script'
     description: "Runs `goimports-reviser -format [args] ./...` to format all go files"
 -   id: revive

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -65,3 +65,9 @@
     files: '\.go$'
     language: 'script'
     description: "Runs `revive [args] ./...` to lint all go files"
+-   id: force-mod-version
+    name: 'force-mod-version'
+    entry: run-force-mod-version.sh
+    pass_filenames: false
+    language: 'script'
+    description: "Force go version in go.mod and go.work files"

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Add this to your `.pre-commit-config.yaml`
 
 - `go-fmt` - Runs `gofmt`, requires golang
 - `go-vet` - Runs `go vet`, requires golang
-- `go-lint` - Runs `golint`, requires <https://github.com/golang/lint> but is unmaintained & deprecated in favour of [`golangci-lint`](https://github.com/golangci/golangci-lint)
+- `go-lint` - Runs `golint`, requires <https://github.com/golang/lint> but is unmaintained & deprecated in favour of [golangci-lint](https://github.com/golangci/golangci-lint)
 - `go-imports` - Runs `goimports`, requires golang.org/x/tools/cmd/goimports
-- `golangci-lint` - Run `golangci-lint run ./...`, requires
-  [golangci-lint](https://github.com/golangci/golangci-lint)
+- `golangci-lint` - Run `golangci-lint run ./...`, requires [golangci-lint](https://github.com/golangci/golangci-lint)
 - `go-unit-tests` - Run `go test` to all project files with coverage
 - `go-mod-tidy` - Run `go mod tidy -v`, requires golang
 - `go-get-update` - Run `go get -u -v ./...` to update all project dependencies if there are any available
-- `goimports-reviser` - Run `goimports-reviser -format [args] ./...` to format all golang files (requires [goimports-reviser cli](https://github.com/incu6us/goimports-reviser))
+- `goimports-reviser` - Run `goimports-reviser -format ./...` to format all golang files (requires [goimports-reviser cli](https://github.com/incu6us/goimports-reviser))
 - `revive` - Runs `revive` to inspect all staged files (requires [revive](https://github.com/mgechev/revive))
+- `force-mod-version` - Search for all go.mod and go.work files and remove specific toolchains and unify to a specific go version (default 1.22)

--- a/run-force-mod-version.sh
+++ b/run-force-mod-version.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+version="1.22"
+
+function sed_replace() {
+  os=$(uname)
+
+  if [ "$os" = "Darwin" ]; then
+    sed -i '' "$1" "$2"
+  else
+    sed -i "$1" "$2"
+  fi
+}
+
+if [ $# -gt 0 ]; then
+  version="$1"
+fi
+
+# Find all go.mod and go.work files recursively
+files=$(find . -type f \( -name "go.mod" -o -name "go.work" \))
+
+if [ -z "$files" ]; then
+  echo "No go.mod or go.work files found"
+  exit 0
+fi
+
+for file in $files; do
+  # Remove gotoolchain line if present
+  if grep -q "^toolchain go" "$file"; then
+    echo "Removing gotoolchain version from $file"
+    sed_replace '/^toolchain go/d' "$file"
+  fi
+
+  # Check if current version is different from target version
+  if current_version=$(grep "^go [0-9]" "$file" | awk '{print $2}'); then
+    if [ "$current_version" != "$version" ]; then
+      echo "Updating go version from $current_version to $version in $file"
+      pattern="s|^go .*|go $version|g"
+      sed_replace "$pattern" "$file"
+    fi
+  fi
+
+  # Add file to git if it has changed
+  if git diff --quiet "$file"; then
+    git add "$file"
+  fi
+done
+
+

--- a/run-goimports-reviser.sh
+++ b/run-goimports-reviser.sh
@@ -3,13 +3,7 @@
 
 set -e -o pipefail
 
-command="goimports-reviser -format"
-
-if [ $# -gt 0 ]; then
-  command="$command $@"
-fi
-
-command="$command ./..."
+command="goimports-reviser -format ./..."
 
 echo "Running: $command"
 


### PR DESCRIPTION
## Description

Adds a new hook `force-mode-version` to fix go.mod and go.work files to a specific version of golang by removing different configured toolchains